### PR TITLE
feat(dashboardFeed): Populate userdashboard feed tab with data

### DIFF
--- a/backend/send/serializers.py
+++ b/backend/send/serializers.py
@@ -1,5 +1,6 @@
 from rest_framework import serializers
 from .models import Boulder, Send
+from django.contrib.auth.models import User
 
 class BoulderSerializer(serializers.ModelSerializer):
     class Meta:
@@ -8,7 +9,11 @@ class BoulderSerializer(serializers.ModelSerializer):
 
 class SendSerializer(serializers.ModelSerializer):
     boulder = BoulderSerializer()  # Nested serializer for Boulder
+    username = serializers.SerializerMethodField()
 
     class Meta:
         model = Send
         fields = '__all__'
+    # This method is caled by the SerializerMethodField to get the username for each send object
+    def get_username(self, obj):
+        return obj.user.username

--- a/backend/send/urls.py
+++ b/backend/send/urls.py
@@ -4,5 +4,5 @@ from send.views import SendView, AllSendsFeedView
 
 urlpatterns = [
     path('', SendView.as_view(), name='send'),
-    path('all-sends-feed', AllSendsFeedView.as_view(), name='all-sends-feed')
+    path('all-sends-feed/', AllSendsFeedView.as_view(), name='all-sends-feed')
 ]

--- a/frontend/src/Features/Dashboard/DashboardFeed.jsx
+++ b/frontend/src/Features/Dashboard/DashboardFeed.jsx
@@ -1,7 +1,50 @@
+
+import { useState, useEffect, useContext } from "react"
+import { getAllSends } from "../../api/Send/backend_calls"
+import TeamSendTable from "../Team/TeamSendTable"
+import UserContext from "../../contexts/UserContext"
+
+
 export default function DashboardFeed(){
+    const [ feedSends, setFeedSends ] = useState([])
+    const { userSends } = useContext(UserContext) // Updates the page if they log while looking at feed
+    
+    const generateFeedSends = async () => {
+        const tenMostRecentSends = await getAllSends()
+        if (tenMostRecentSends.status == 200){
+            const formattedSends = tenMostRecentSends.data.map(send => ({
+                id: send.id,
+                username: send.username,
+                boulder: send.boulder.name,
+                grade: send.boulder.grade,
+                score: send.score,
+                send_date: send.send_date,
+
+
+                
+            }))
+            setFeedSends(formattedSends)
+        }
+    }
+
+
+    useEffect(()=> {
+        generateFeedSends()
+    }, [userSends]) // Only will run if user logs a Send while rendering DashboardFeed
+    // Otherwise useEffect will run once
+    // Clicking the component after navigating away will fetch again
+
+
+    /// Using TeamSendTable as placeholder
+    // There are several pages formatted similarly
+    // Where we display something like
+    // Username, Boulder Name, Grade, Score, Send Date
+
+    // We should make a reuseable component to handle this data
     return (
     <>
-    <h1 className="font-nunito text-white text-4xl">This is the start of the feed page</h1>
-    <p className="text-white font-nunito">Gonna be pretty sweet</p>
+    {feedSends && (
+        <TeamSendTable teamSends={feedSends} />
+    )}
     </>)
 }

--- a/frontend/src/api/Send/backend_calls.js
+++ b/frontend/src/api/Send/backend_calls.js
@@ -17,3 +17,19 @@ export async function logSend(context){
     }
   }
 
+
+export async function getAllSends(){
+    try {
+        const response = axios.get(`http://${host}/api/v1/send/all-sends-feed/`, {
+            headers: {
+                "Content-Type": "application/json",
+                "Authorization": `Token ${localStorage.getItem("token")}`
+            }
+        })
+        return response
+    } catch (error) {
+        console.error("Something went wrong in getAllSends", error.response.status)
+        throw error
+    }
+}
+

--- a/frontend/src/routes/Team.jsx
+++ b/frontend/src/routes/Team.jsx
@@ -124,7 +124,6 @@ const teamSendData = []
     navigate(`/upload-image/team/${teamId}`)
   }
 
-  
 
   return (
     <div className="bg-night min-h-screen py-4">


### PR DESCRIPTION
- Connected backend endpoint that retrieves ten most recent sends
- Updated Send Serializer to include username in Send Objects

- Currently reused TeamSendTable to display feed data
- We should make a reusable table component in the future

Fixes #170